### PR TITLE
HybridScan supports ZSTD decomp with DirectBuffer

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuParquetScan.scala
@@ -1140,7 +1140,8 @@ case class GpuParquetMultiFilePartitionReaderFactory(
     rapidsConf.parquetScanHostBatchSizeBytes,
     3,
     rapidsConf.parquetScanEnableDictLateMat,
-    rapidsConf.parquetScanHostAsync)
+    rapidsConf.parquetScanHostAsync,
+    rapidsConf.parquetScanUnsafeDecompression)
 
   // We can't use the coalescing files reader when InputFileName, InputFileBlockStart,
   // or InputFileBlockLength because we are combining all the files into a single buffer
@@ -2623,7 +2624,7 @@ class MultiFileCloudParquetPartitionReader(
           hostBuffer, 0, dataSize, metrics,
           dateRebaseMode, timestampRebaseMode, hasInt96Timestamps,
           clippedSchema, readDataSchema,
-          slotAcquired, opts.enableDictLateMat, opts.async)
+          slotAcquired, opts.enableDictLateMat, opts.async, opts.unsafeDecompression)
 
         val batchIter = HostParquetIterator(asyncReader, opts, colTypes, metrics)
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/RapidsConf.scala
@@ -1545,26 +1545,32 @@ val GPU_COREDUMP_PIPE_PATTERN = conf("spark.rapids.gpu.coreDump.pipePattern")
     .stringConf
     .createWithDefault("GPU_ONLY")
 
-  val PARQUET_HOST_SCAN_PARALLELISM = conf("spark.rapids.sql.parquet.scan.hostParallelism")
+  val PARQUET_CPU_SCAN_PARALLELISM = conf("spark.rapids.sql.parquet.scan.hostParallelism")
     .doc("The max concurrent capacity for host parquet scan(decode) tasks")
     .internal()
     .integerConf
     .createWithDefault(0)
 
-  val PARQUET_HOST_SCAN_BATCH_SIZE_BYTES = conf("spark.rapids.sql.parquet.scan.hostBatchSizeBytes")
+  val PARQUET_CPU_SCAN_BATCH_SIZE_BYTES = conf("spark.rapids.sql.parquet.scan.hostBatchSizeBytes")
     .doc("Similar to spark.rapids.sql.batchSizeBytes, but it is only for decode tasks run on CPUs")
     .internal()
     .integerConf
     .createWithDefault(1024 * 1024 * 128)
 
-  val PARQUET_HOST_SCAN_ASYNC = conf("spark.rapids.sql.parquet.scan.async")
+  val PARQUET_CPU_SCAN_ASYNC = conf("spark.rapids.sql.parquet.scan.async")
     .doc("Whether run host parquet decode tasks asynchronously or not")
     .internal()
     .booleanConf
-    .createWithDefault(false)
+    .createWithDefault(true)
 
-  val PARQUET_SCAN_DICT_LATE_MAT = conf("spark.rapids.sql.parquet.scan.enableDictLateMat")
+  val PARQUET_CPU_SCAN_DICT_LATE_MAT = conf("spark.rapids.sql.parquet.scan.enableDictLateMat")
     .doc("Whether pushing down binary dicts onto GPU and materializing via GPU or not")
+    .internal()
+    .booleanConf
+    .createWithDefault(true)
+
+  val PARQUET_CPU_SCAN_UNSAFE_DECOMP = conf("spark.rapids.sql.parquet.scan.unsafeDecompress")
+    .doc("Whether using UnsafeDecompressor instead of the default one of parquet-hadoop or not")
     .internal()
     .booleanConf
     .createWithDefault(false)
@@ -2630,13 +2636,15 @@ class RapidsConf(conf: Map[String, String]) extends Logging {
 
   lazy val parquetScanHybridMode: String = get(PARQUET_HYBRID_SCAN_MODE)
 
-  lazy val parquetScanHostParallelism: Int = get(PARQUET_HOST_SCAN_PARALLELISM)
+  lazy val parquetScanHostParallelism: Int = get(PARQUET_CPU_SCAN_PARALLELISM)
 
-  lazy val parquetScanHostBatchSizeBytes: Int = get(PARQUET_HOST_SCAN_BATCH_SIZE_BYTES)
+  lazy val parquetScanHostBatchSizeBytes: Int = get(PARQUET_CPU_SCAN_BATCH_SIZE_BYTES)
 
-  lazy val parquetScanHostAsync: Boolean = get(PARQUET_HOST_SCAN_ASYNC)
+  lazy val parquetScanHostAsync: Boolean = get(PARQUET_CPU_SCAN_ASYNC)
 
-  lazy val parquetScanEnableDictLateMat: Boolean = get(PARQUET_SCAN_DICT_LATE_MAT)
+  lazy val parquetScanEnableDictLateMat: Boolean = get(PARQUET_CPU_SCAN_DICT_LATE_MAT)
+
+  lazy val parquetScanUnsafeDecompression: Boolean = get(PARQUET_CPU_SCAN_UNSAFE_DECOMP)
 
   lazy val orcDebugDumpPrefix: Option[String] = get(ORC_DEBUG_DUMP_PREFIX)
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/ByteBufferIsConsumer.java
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/ByteBufferIsConsumer.java
@@ -71,7 +71,8 @@ public abstract class ByteBufferIsConsumer {
 	public static ByteBufferIsConsumer create(ByteBufferInputStream bis) {
 		List<ByteBuffer> buffers = bis.remainingBuffers();
 		if (buffers.isEmpty()) {
-			throw new IllegalArgumentException("Got empty ByteBufferInputStream");
+			System.err.println("Got empty ByteBufferInputStream");
+			return new EmptyBufferIsConsumer();
 		}
 		if (buffers.size() > 1) {
 			System.err.printf("create a MultiByteBuffersConsumer with %d buffers\n", buffers.size());
@@ -82,5 +83,4 @@ public abstract class ByteBufferIsConsumer {
 		}
 		return new DirectByteBufferIsConsumer(buffers.iterator());
 	}
-
 }

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/EmptyBufferIsConsumer.java
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/EmptyBufferIsConsumer.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.parquet.rapids;
+
+import com.google.common.collect.Iterators;
+import org.apache.parquet.io.api.Binary;
+import org.apache.spark.sql.execution.vectorized.rapids.WritableColumnVector;
+
+public class EmptyBufferIsConsumer extends ByteBufferIsConsumer {
+
+	public EmptyBufferIsConsumer() {
+		super(Iterators.emptyIterator());
+	}
+
+	@Override
+	public void readInts(int total, WritableColumnVector c, int rowId) {
+		throw new AssertionError("We should NOT perform any reading from EmptyBufferIsConsumer");
+	}
+
+	@Override
+	public void readLongs(int total, WritableColumnVector c, int rowId) {
+		throw new AssertionError("We should NOT perform any reading from EmptyBufferIsConsumer");
+	}
+
+	@Override
+	public void readFloats(int total, WritableColumnVector c, int rowId) {
+		throw new AssertionError("We should NOT perform any reading from EmptyBufferIsConsumer");
+	}
+
+	@Override
+	public void readDoubles(int total, WritableColumnVector c, int rowId) {
+		throw new AssertionError("We should NOT perform any reading from EmptyBufferIsConsumer");
+	}
+
+	@Override
+	public void readUIntsAsLongs(int total, WritableColumnVector c, int rowId) {
+		throw new AssertionError("We should NOT perform any reading from EmptyBufferIsConsumer");
+	}
+
+	@Override
+	public void readIntsAsShorts(int total, WritableColumnVector c, int rowId) {
+		throw new AssertionError("We should NOT perform any reading from EmptyBufferIsConsumer");
+	}
+
+	@Override
+	public void readIntsAsBytes(int total, WritableColumnVector c, int rowId) {
+		throw new AssertionError("We should NOT perform any reading from EmptyBufferIsConsumer");
+	}
+
+	@Override
+	public void readBinaries(int total, WritableColumnVector c, int rowId) {
+		throw new AssertionError("We should NOT perform any reading from EmptyBufferIsConsumer");
+	}
+
+	@Override
+	public byte getByte() {
+		throw new AssertionError("We should NOT perform any reading from EmptyBufferIsConsumer");
+	}
+
+	@Override
+	public int getInt() {
+		throw new AssertionError("We should NOT perform any reading from EmptyBufferIsConsumer");}
+
+	@Override
+	public long getLong() {
+		throw new AssertionError("We should NOT perform any reading from EmptyBufferIsConsumer");
+	}
+
+	@Override
+	public float getFloat() {
+		throw new AssertionError("We should NOT perform any reading from EmptyBufferIsConsumer");
+	}
+
+	@Override
+	public double getDouble() {
+		throw new AssertionError("We should NOT perform any reading from EmptyBufferIsConsumer");
+	}
+
+	@Override
+	public Binary getBinary(int len) {
+		throw new AssertionError("We should NOT perform any reading from EmptyBufferIsConsumer");
+	}
+}

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/ParquetDirectCodecFactory.java
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/ParquetDirectCodecFactory.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.parquet.rapids;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.github.luben.zstd.ZstdDirectBufferDecompressingStream;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.compress.CodecPool;
+import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.hadoop.io.compress.Decompressor;
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.hadoop.CodecFactory;
+import org.apache.parquet.hadoop.codec.ZstandardCodec;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+
+public class ParquetDirectCodecFactory extends CodecFactory {
+
+	public ParquetDirectCodecFactory(Configuration configuration, int pageSize) {
+		super(configuration, pageSize);
+	}
+
+	@SuppressWarnings("deprecation")
+	class DirectBytesDecompressor extends BytesDecompressor {
+
+		private final CompressionCodec codec;
+		private final Decompressor decompressor;
+
+		DirectBytesDecompressor(CompressionCodecName codecName) {
+			this.codec = getCodec(codecName);
+			if (codec != null) {
+				decompressor = CodecPool.getDecompressor(codec);
+			} else {
+				decompressor = null;
+			}
+		}
+
+		@Override
+		public BytesInput decompress(BytesInput bytes, int uncompressedSize) throws IOException {
+			if (codec == null) {
+				return bytes;
+			}
+			if (decompressor != null) {
+				decompressor.reset();
+			}
+			if (!(codec instanceof ZstandardCodec)) {
+				InputStream is = codec.createInputStream(bytes.toInputStream(), decompressor);
+				return BytesInput.from(is, uncompressedSize);
+			}
+
+			return decompressZstd(bytes);
+		}
+
+		@Override
+		public void decompress(
+				ByteBuffer input, int compressedSize, ByteBuffer output, int uncompressedSize)
+				throws IOException {
+			ByteBuffer decompressed =
+					decompress(BytesInput.from(input), uncompressedSize).toByteBuffer();
+			output.put(decompressed);
+		}
+
+		@Override
+		public void release() {
+			if (decompressor != null) {
+				CodecPool.returnDecompressor(decompressor);
+			}
+		}
+
+		/**
+		 * Perform zstd decompression with direct memory as input and output
+		 * <p>
+		 * 1. Exhaust the input data;
+		 * 2. complete all the decompression work eagerly;
+		 * 3. return uncompressed buffers;
+		 */
+		private BytesInput decompressZstd(BytesInput bytes) throws IOException {
+			List<ByteBuffer> inputBuffers;
+			try (ByteBufferInputStream is = bytes.toInputStream()) {
+				inputBuffers = is.remainingBuffers();
+			}
+			if (inputBuffers.isEmpty()) {
+				throw new IllegalArgumentException("Got empty ByteBufferInputStream");
+			}
+			// Compute the total size of compressed data
+			int totalUncompressedSize = 0;
+			ByteBuffer tmpBlk = null;
+
+			List<ByteBuffer> decompressedBlocks = new ArrayList<>();
+			ZstdDirectBufferDecompressingStream zis = null;
+			try {
+				for (ByteBuffer inputBuffer: inputBuffers) {
+					zis = new ZstdDirectBufferDecompressingStream(inputBuffer);
+					zis.setFinalize(false);
+					while (zis.hasRemaining()) {
+						if (tmpBlk == null || tmpBlk.remaining() < 64) {
+							if (tmpBlk != null) {
+								tmpBlk.flip();
+								totalUncompressedSize += tmpBlk.remaining();
+								decompressedBlocks.add(tmpBlk);
+							}
+							tmpBlk = ByteBuffer.allocateDirect(RECOMMENDED_BATCH_SIZE);
+						}
+						zis.read(tmpBlk);
+					}
+					zis.close();
+					zis = null;
+				}
+				// append the tailing block if exists
+				if (tmpBlk != null) {
+					tmpBlk.flip();
+					totalUncompressedSize += tmpBlk.remaining();
+					decompressedBlocks.add(tmpBlk);
+				}
+				// merge all blocks into a continuous fused buffer
+				ByteBuffer concatBuffer = ByteBuffer.allocate(totalUncompressedSize);
+				for (ByteBuffer blk : decompressedBlocks) {
+					concatBuffer.put(blk);
+				}
+				concatBuffer.flip();
+
+				return BytesInput.from(concatBuffer);
+
+			} catch (Throwable ex) {
+				if (zis != null) {
+					zis.close();
+				}
+				for (ByteBuffer buf: inputBuffers) {
+					buf.clear();
+				}
+				for (ByteBuffer buf: decompressedBlocks) {
+					buf.clear();
+				}
+				throw new RuntimeException(ex);
+			}
+		}
+	}
+
+	@Override
+	@SuppressWarnings("deprecation")
+	protected BytesDecompressor createDecompressor(CompressionCodecName codecName) {
+		return new ParquetDirectCodecFactory.DirectBytesDecompressor(codecName);
+	}
+
+	private static final int RECOMMENDED_BATCH_SIZE = 128 * 1024;
+}

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/ParquetHeapCodecFactory.java
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/ParquetHeapCodecFactory.java
@@ -34,9 +34,9 @@ import org.apache.parquet.hadoop.metadata.CompressionCodecName;
  * workaround for memory issues encountered when reading from zstd-compressed files. For
  * details, see <a href="https://issues.apache.org/jira/browse/PARQUET-2160">PARQUET-2160</a>
  */
-public class ParquetCodecFactory extends CodecFactory {
+public class ParquetHeapCodecFactory extends CodecFactory {
 
-	public ParquetCodecFactory(Configuration configuration, int pageSize) {
+	public ParquetHeapCodecFactory(Configuration configuration, int pageSize) {
 		super(configuration, pageSize);
 	}
 

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/VectorizedPlainValuesReader.java
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/rapids/VectorizedPlainValuesReader.java
@@ -16,8 +16,6 @@
 
 package org.apache.spark.sql.execution.datasources.parquet.rapids;
 
-import java.io.IOException;
-
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.column.values.ValuesReader;


### PR DESCRIPTION
1. add `ParquetDirectCodecFactory` to support ZSTD decomp with DirectBuffer
2. Fix "Got empty ByteBufferInputStream" exception